### PR TITLE
Setting 30s timeout

### DIFF
--- a/src/HTTP/Connection.cpp
+++ b/src/HTTP/Connection.cpp
@@ -9,6 +9,7 @@ namespace HTTP {
 	Connection::Connection(int connection_socket_fd)
 		// Connection::Connection(int connection_socket_fd, int server_listening_sockfd, sockaddr_in& connection_addr, int connection_addr_len)
 		: _socket_fd(connection_socket_fd)
+		, _is_open(true)
 		, request_handler(new RequestHandler(*this))
 	// , _listening_socket_fd(server_listening_sockfd)
 	// , _client_addr(connection_addr)
@@ -20,6 +21,10 @@ namespace HTTP {
 
 	void Connection::handle_http_request() {
 		request_handler->handle_http_request();
+	}
+
+	bool Connection::is_connection_open() const {
+		return _is_open;
 	}
 
 	void Connection::send(const void* buffer, size_t buffer_size) {
@@ -34,6 +39,7 @@ namespace HTTP {
 			std::cout << "Socket closing failed. errno: " << errno << std::endl;
 		} else {
 			std::cout << "Socket " << _socket_fd << " is closed." << std::endl; // for debug
+			_is_open = false;
 		}
 	}
 

--- a/src/HTTP/Connection.hpp
+++ b/src/HTTP/Connection.hpp
@@ -12,6 +12,7 @@ namespace HTTP {
 	{
 	private:
 		int _socket_fd;
+		bool _is_open;
 		Utility::SmartPointer<RequestHandler> request_handler;
 		// std::auto_ptr<RequestHandler> request_handler;
 
@@ -24,6 +25,7 @@ namespace HTTP {
 		~Connection();
 
 		void handle_http_request();
+		bool is_connection_open() const;
 		virtual size_t receive(char *buffer, size_t buffer_size);
 		virtual void send(const void *buffer, size_t buffer_size);
 		virtual void close();

--- a/src/HTTP/Server.cpp
+++ b/src/HTTP/Server.cpp
@@ -9,6 +9,7 @@
 #include  <cstdlib> // for exit
 #include <cstdio> // for perror
 #include <fcntl.h> // for fcntl
+#include <sys/time.h> // for timeout
 #ifdef _LINUX
 	#include "/usr/include/kqueue/sys/event.h" //linux kqueue
 #else
@@ -103,11 +104,26 @@ namespace HTTP {
 			}
 		}
 		while (true) {
-			//TODO: addding timeout as the last parameter?
-			int new_events = kevent(sock_kqueue, NULL, 0, event_fds, 1, NULL);//look out for events and register to event list; one event per time
+			struct timespec timeout;
+			timeout.tv_sec = 30; // setting the 30s timeout
+			timeout.tv_nsec = 0;
+			int new_events = kevent(sock_kqueue, NULL, 0, event_fds, 1, &timeout); //look out for events and register to event list; one event per time
 			if(new_events == -1) {
 				std::perror("kevent");
 				std::exit(1);
+			}
+			if(new_events == 0) {
+				std::map<int, Connection*>::iterator iter = _connections.begin();
+				while (iter != _connections.end()) {
+					if (iter->second->is_connection_open()) {
+						close(iter->first);
+					}
+					_connections.erase(iter);
+					if (_connections.size() == 0) {
+						break;
+					}
+					iter++;
+				}
 			}
 			for(int i = 0; i < new_events; i++) {
 				int current_event_fd = event_fds[i].ident;


### PR DESCRIPTION
`Kevent` system call is waiting for a new event for 30 seconds and returns. If no new event was spotted the hanging connections are closed and the `_connections` map is cleared