### PR TITLE
Parser + Reader end point logic changed

### DIFF
--- a/src/HTTPRequest/RequestParser.cpp
+++ b/src/HTTPRequest/RequestParser.cpp
@@ -59,12 +59,12 @@ namespace HTTPRequest {
     }
 
     void RequestParser::parse_HTTP_request(char* buffer, size_t bytes_read) {
-        char* buffer_end = buffer + bytes_read;
         size_t content_length = 0;
-        while (buffer != buffer_end || _current_parsing_state != FINISHED)
+        size_t bytes_parsed = 0;
+        while (bytes_parsed != bytes_read || _current_parsing_state != FINISHED)
         {
             bool can_be_parsed = false;
-            std::string line = _request_reader.read_line(&buffer, buffer_end, &can_be_parsed);
+            std::string line = _request_reader.read_line(buffer, bytes_read, &bytes_parsed, &can_be_parsed);
             if (_current_parsing_state == MESSAGE_BODY && line.size() == content_length) {
                 can_be_parsed = true;
             }
@@ -77,11 +77,9 @@ namespace HTTPRequest {
                     _define_message_body_length();
                     if (_message_body_length == CONTENT_LENGTH) {
                         content_length = _set_content_length();
-                        buffer_end = buffer + content_length;
                     }
                     //TODO: validate request line
                     //TODO: validate headers
-                    //TODO: what if content-length is less than bytes read? Do we close the connection or need to support keep-alive?
                 }
             }
         }

--- a/src/HTTPRequest/RequestReader.hpp
+++ b/src/HTTPRequest/RequestReader.hpp
@@ -13,13 +13,12 @@ namespace HTTPRequest {
 		std::string _accumulator;
 		static size_t _length_counter;
 		
-		bool _is_end_of_line(char *current_string, char* message_end);
+		bool _is_end_of_line(char character);
 
 	public:
 		RequestReader();
 		~RequestReader();
-		
-		std::string read_line(char** buffer, char* buffer_end, bool* can_be_parsed);
+
+		std::string read_line(char* buffer, size_t bytes_read, size_t* bytes_parsed, bool* can_be_parsed);
 	};
 }
-


### PR DESCRIPTION
Parser and Reader are comparing bytes read with the bytes parsed. They both stop when the number is equal.
This solves the issue with the edge_case when the Content_length passed is bigger than the message body. In this case the parser is not returning. Connection will be closed on timeout(will be fixed when the solution for [issue#27](https://github.com/Mollie-S/webserver/issues/27) is implemented)