### PR TITLE
C str memory free

### DIFF
--- a/src/CGI/CGIHandler.cpp
+++ b/src/CGI/CGIHandler.cpp
@@ -38,10 +38,25 @@ CGIHandler::CGIHandler(){
 	_output_pipe[1] = -1;
 
 	_response = "";
+	initialize_cgi_arguments();
 }
 
 CGIHandler::~CGIHandler(){
-//TODO is there any memory to be freed?
+	for (int i = 0; i < Constants::ENVP_SIZE; i++) {
+		free(_envp[i]);
+	}
+	for (int i = 0; i < Constants::ARGUMENTS_SIZE; i++) {
+		free(_argument[i]);
+	}
+}
+
+void CGIHandler::initialize_cgi_arguments() {
+	for (int i = 0; i < Constants::ENVP_SIZE; i++) {
+		_envp[i] = NULL;
+	}
+	for (int i = 0; i < Constants::ARGUMENTS_SIZE; i++) {
+		_argument[i] = NULL;
+	}
 }
 
 /* append the cgi-bin location to the path after the script in the uri */
@@ -103,7 +118,6 @@ void CGIHandler::set_envp(void)
 		_envp[i] = strdup(temp.c_str());
 		i++;
 	}
-	_envp[i] = NULL;
 }
 
 void CGIHandler::set_argument(std::string cgi_name)
@@ -112,7 +126,6 @@ void CGIHandler::set_argument(std::string cgi_name)
 	std::string full_path = std::string(cwd) + "/cgi-bin/" + cgi_name; //define the default cgi-bin (should be in the same location with the executable)
 	free(cwd);					  
 	_argument[0] = strdup(full_path.c_str());
-	_argument[1] = NULL;
 }
 
 //input parameter will be uriData->get_path()

--- a/src/CGI/CGIHandler.hpp
+++ b/src/CGI/CGIHandler.hpp
@@ -8,23 +8,27 @@
 
 #include "../HTTPRequest/RequestMessage.hpp"
 #include "../HTTPResponse/SpecifiedConfig.hpp"
+#include "../Constants.hpp"
 
 class CGIHandler
 {
 private:
-	char *_envp[21];				// TODO check if this is the right size, terminated with 0
-	char *_argument[2];
+	char *_envp[Constants::ENVP_SIZE];		// TODO check if this is the right size, terminated with 0
+	char *_argument[Constants::ARGUMENTS_SIZE];
 	std::map<std::string, std::string> _meta_variables;
 	std::string _cgi_name;
 	std::vector<std::string> _cgi_extention;
 	bool _search_cgi_extension;
-	void update_path_translated(void);
 	int _input_pipe[2];
 	int _output_pipe[2];
 	int _socket_fd;
 	std::string _response;
 	std::string _request_message_body;
-	class CGIexception: public std::exception{
+
+	void update_path_translated(void);
+	void initialize_cgi_arguments();
+	class CGIexception : public std::exception
+	{
 		const char* what() const _NOEXCEPT { return "internal server error"; }
 	};
 

--- a/src/Constants.hpp
+++ b/src/Constants.hpp
@@ -17,7 +17,9 @@
 namespace Constants {
 	const int PAYLOAD_MAX_LENGTH = 2097152; // 2MB
 	const int SEND_BUFFER_SIZE = 32768; // 32kB
-	const int DEFAULT_MAX_SIZE_BODY = 8000000;
+	const int DEFAULT_MAX_SIZE_BODY = 8000000; // 8MB
+	const int ENVP_SIZE = 21;
+	const int ARGUMENTS_SIZE = 2;
 	const double CONNECTIONS_CHECKER_INTERVAL = 10;
 	const double NO_ACTIVITY_TIMEOUT = 30;
 }


### PR DESCRIPTION
Memory allocated by strdup is freed in CGI destructor.
Arguments initialised in the constructor.
Constants defining the size of envp and arguments in cgi added.